### PR TITLE
Fix breaking change of adding "ca-central-1" as the default region

### DIFF
--- a/src/django_iam_dbauth/aws/database_wrapper.py
+++ b/src/django_iam_dbauth/aws/database_wrapper.py
@@ -8,7 +8,7 @@ from django_iam_dbauth.utils import resolve_cname
 def get_aws_connection_params(params):
     enabled = params.pop("use_iam_auth", None)
     if enabled:
-        region_name = params.pop("region_name", "ca-central-1")
+        region_name = params.pop("region_name", None)
         rds_client = boto3.client(service_name="rds", region_name=region_name)
 
         hostname = params.get("host")


### PR DESCRIPTION
This PR fixes a breaking change introduce when setting as default `"ca-central-1"` instead of levaraging it to boto3  see
https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html