### PR TITLE
wrong key name error resolved

### DIFF
--- a/src/django_iam_dbauth/aws/database_wrapper.py
+++ b/src/django_iam_dbauth/aws/database_wrapper.py
@@ -6,7 +6,7 @@ from django_iam_dbauth.utils import resolve_cname
 
 
 def get_aws_connection_params(params):
-    enabled = params.pop("use_iam_auth", None)
+    enabled = params.pop("user_iam_auth", None)
     if enabled:
         region_name = params.pop("region_name", None)
         rds_client = boto3.client(service_name="rds", region_name=region_name)


### PR DESCRIPTION
When using AWS RDS for IAM token based Authentication, I found key "uses_iam_auth" in the DATABASE Options was misspelt as "use_iam_auth" in the "src\django_iam_dbauth\aws\database_wrapper.py".
Corrected this mistake and created a pull request for it.