### PR TITLE
Adds resolve_cname_enabled option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ DATABASES = {
         "OPTIONS": {
             "use_iam_auth": True,
             "sslmode": "require",   # See discussion on SSL below
+            "resolve_cname_enabled": True,
         }
     }
 }
@@ -37,6 +38,10 @@ When using IAM authentication with RDS, SSL is required. If it's not used, such 
 ```
 django.db.utils.OperationalError: FATAL:  pg_hba.conf rejects connection for host "1.2.3.4", user "some_user", database "some_database", SSL off
 ```
+
+### SSL and MySQL
+
+Acquired Token won't work with MySQL if use RDS instance name, which is a CNAME record, as a HOST, because by default it will be resolved to a cannonical name by django-iam-dbauth. As a result the hostname of the token will bi different. To prevent the module from resolving CNAME, set "resolve_cname_enabled" to False.
 
 ### CNAME considerations
 

--- a/src/django_iam_dbauth/aws/database_wrapper.py
+++ b/src/django_iam_dbauth/aws/database_wrapper.py
@@ -12,7 +12,11 @@ def get_aws_connection_params(params):
         rds_client = boto3.client(service_name="rds", region_name=region_name)
 
         hostname = params.get("host")
-        hostname = resolve_cname(hostname) if hostname else "localhost"
+        if hostname:
+            hostname = resolve_cname(hostname) if params.pop(
+                "resolve_cname_enabled", True) else hostname
+        else:
+            hostname = "localhost"
 
         params["password"] = rds_client.generate_db_auth_token(
             DBHostname=hostname,


### PR DESCRIPTION
Adds resolve_cname_enabled option that allows to disable cname resolution
inside get_aws_connection_params. This eliminates discrepancy in
RDS instance CNAME and the canonical name the CNAME resolve to.
As a result Django is able to acquire a token and authenticate in Mysql
behind this record.